### PR TITLE
Changed wrong text

### DIFF
--- a/src/Components/RequestCard.tsx
+++ b/src/Components/RequestCard.tsx
@@ -252,7 +252,7 @@ const RequestCard = ({ request, isMySentRequest }: Props) => {
                 {/* mySent && denied */}
                 {isMySentRequest && reqStatus === denied ? (
                     <Typography sx={[reqStatusStyle, deniedStyle]} variant="h5">
-                        You have denied this request
+                        Your request is denied
                     </Typography>
                 ) : null}
 


### PR DESCRIPTION
_Texten för om en request man har gjort har blivit nekad är samma som den för om man själv har nekat en förfrågan (”You have denied this request”) vilket är missvisande._
- Texten som var skriven i koden var fel. Är nu ändrad till "Your request is denied"